### PR TITLE
Add import of errno module

### DIFF
--- a/pyrocopy/pyrocopy.py
+++ b/pyrocopy/pyrocopy.py
@@ -25,6 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 '''
 
+import errno
 import fnmatch
 import logging
 import os


### PR DESCRIPTION
This is needed for the errno checking in the `try...except...` clause of `_copyStats()`. Addresses issue #4.